### PR TITLE
Pre and Post Backup Script Support

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -10,11 +10,15 @@ ECHO=`which echo`
 HOST=`which hostname`
 
 CURL=`which curl`
+DIRNAME=`which dirname`
 LS=`which ls`
+PWD=`which pwd`
 OPENSSL=`which openssl`
 RSYNC=`which rsync`
 TAR=`which tar`
 BINARIES=("curl" "openssl" "rsync" "tar")
+
+SCRIPT_DIR=$()
 ### END VAR SETUP ###
 
 ### BEGIN FUNCTIONS ###
@@ -77,16 +81,16 @@ copy_backup() {
 
 pre_backup() {
     # -n = The length of STRING is greater than zero
-    if [ -n "$(${LS} -A ${PWD}/pre_scripts/ 2>/dev/null)" ]; then
+    if [ -n "$(${LS} -A $SCRIPT_DIR/pre_scripts/ 2>/dev/null)" ]; then
         log "INFO" "Pre-backup script(s) found! Executing script(s)..."
-        for i in `${LS} ${PWD}/pre_scripts/`; do
+        for i in `${LS} $SCRIPT_DIR/pre_scripts/`; do
             if [ ! -z "$DEBUG" ]; then
-                /bin/bash "${PWD}/pre_scripts/$i" 2>/dev/null
+                /bin/bash "$SCRIPT_DIR/pre_scripts/$i" 2>/dev/null
             else
-                /bin/bash "${PWD}/pre_scripts/$i"
+                /bin/bash "$SCRIPT_DIR/pre_scripts/$i"
             fi
             if [ "$?" != 0 ]; then
-                log "ERROR" "${PWD}/pre_scripts/$i exited with $?! Consider enabling DEBUG logging..."
+                log "ERROR" "$SCRIPT_DIR/pre_scripts/$i exited with $?! Consider enabling DEBUG logging..."
                 exit 1007
             fi
         done
@@ -95,16 +99,16 @@ pre_backup() {
 
 post_backup() {
     # -n = The length of STRING is greater than zero
-    if [ -n "$(${LS} -A ${PWD}/post_scripts/ 2>/dev/null)" ]; then
+    if [ -n "$(${LS} -A $SCRIPT_DIR/post_scripts/ 2>/dev/null)" ]; then
         log "INFO" "Post-backup script(s) found! Executing script(s)..."
-        for i in `${LS} ${PWD}/post_scripts/`; do
+        for i in `${LS} $SCRIPT_DIR/post_scripts/`; do
             if [ ! -z "$DEBUG" ]; then
-                /bin/bash "${PWD}/post_scripts/${i}" 2>/dev/null
+                /bin/bash "$SCRIPT_DIR/post_scripts/$i" 2>/dev/null
             else
-                /bin/bash "${PWD}/post_scripts/${i}"
+                /bin/bash "$SCRIPT_DIR/post_scripts/$i"
             fi
             if [ "$?" != 0 ]; then
-                log "ERROR" "${PWD}/post_scripts/${i} exited with ${$?}! Consider enabling DEBUG logging..."
+                log "ERROR" "$SCRIPT_DIR/post_scripts/$i exited with $?! Consider enabling DEBUG logging..."
                 exit 1008
             fi
         done

--- a/backup.sh
+++ b/backup.sh
@@ -18,7 +18,7 @@ RSYNC=`which rsync`
 TAR=`which tar`
 BINARIES=("curl" "openssl" "rsync" "tar")
 
-SCRIPT_DIR=$()
+SCRIPT_DIR=$(${DIRNAME} -- "$0")
 ### END VAR SETUP ###
 
 ### BEGIN FUNCTIONS ###

--- a/post_scripts/example.sh
+++ b/post_scripts/example.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# You can have as many scripts here as you'd like, as long as they are BASH/SH scripts
+# Examples of what can go in a pre-backup script would be starting of services or scheduling
+# tasks to kick off or stop, etc

--- a/pre_scripts/example.sh
+++ b/pre_scripts/example.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# You can have as many scripts here as you'd like, as long as they are BASH/SH scripts
+# Examples of what can go in a pre-backup script would be stopping of services or scheduling
+# tasks to kick off or stop, etc


### PR DESCRIPTION
- added in support for pre-backup scripts
- added in support for post-backup scripts
- fixed a bug with openssl warnings not being suppressed in the log without debug
- fixed a bug with tar warnings not being suppressed in the log without debug
- fixing bug with determining scripts working directory
- fixing bugs with references to variables in post_backup() function
- fixing script_dir variable to use dirname to get the right directory