### PR TITLE
fix bug in required_options function

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -381,7 +381,7 @@ required_options() {
     for ((i=0; i < ${#OPTIONS[@]}; i++)); do
         if [ ! -v "${OPTIONS[i]}" ]; then
             log "ERROR" "Problem detected with ${OPTIONS[i]}! Please double-check your config file!"
-            return 1
+            error=1
         fi
     done
 


### PR DESCRIPTION
fixed a bug in required_options function that did not set the error value correctly when the config is missing an option